### PR TITLE
fix: preserve Workchat document selection

### DIFF
--- a/src/stores/workchat.js
+++ b/src/stores/workchat.js
@@ -1,0 +1,12 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useWorkchatStore = defineStore('workchat', () => {
+  // Keep selected context items while switching away from /workchat.
+  // This is intentionally session-scoped; it should reset after an app reload.
+  const ctxItems = ref([])
+
+  return {
+    ctxItems,
+  }
+})

--- a/src/views/workchat/index.vue
+++ b/src/views/workchat/index.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, computed, nextTick, onMounted, onBeforeUnmount, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import { useResizeObserver, useWindowSize } from '@vueuse/core'
 import { useAppStore } from '@/stores/app'
 import { useConversationsStore } from '@/stores/conversations'
@@ -7,6 +8,7 @@ import { useAgentsStore } from '@/stores/agents'
 import { useWikiStore } from '@/stores/wiki'
 import { useSettingsStore } from '@/stores/settings'
 import { useUserStore } from '@/stores/user'
+import { useWorkchatStore } from '@/stores/workchat'
 import { AgentRuntime } from '@/agents/AgentRuntime'
 import { normalizeFilePath } from '@/utils/fileUrl'
 import { readableGenerationContexts } from '@/utils/generationContext'
@@ -40,6 +42,8 @@ const agentsStore = useAgentsStore()
 const wikiStore = useWikiStore()
 const settingsStore = useSettingsStore()
 const userStore = useUserStore()
+const workchatStore = useWorkchatStore()
+const { ctxItems: globalCtxItems } = storeToRefs(workchatStore)
 const isDark = computed(() => appStore.isDark)
 const msg = useMessage()
 
@@ -175,7 +179,6 @@ function findBuiltinAgentByEnglishName(englishName, fallbackIds = []) {
   ))
 }
 
-const globalCtxItems = ref([])
 const currentCtxItems = computed(() => globalCtxItems.value)
 const selectedWikiIds = ref([])
 const availableWikis = computed(() => wikiStore.wikis || [])


### PR DESCRIPTION
## Summary
- Fixes #4
- Preserve the selected Workchat document context while switching away from and back to the Workchat page
- Move the Workchat context item state from a component-local `ref` into a small session-scoped Pinia store

## Rationale
The selected document context was stored inside `src/views/workchat/index.vue` as a local `ref`. When navigating to another left-side page, the Workchat component can be unmounted, so the local state is recreated when returning and the selected document is no longer kept.

This PR keeps the change intentionally small and session-scoped:
- no localStorage/sessionStorage persistence
- no route-level behavior change
- no database or config changes
- state still resets after app reload

## Testing
Tested on Windows 11:
- `pnpm exec vite build` passed
- launched the app with `pnpm dev`
- confirmed the Reviva Electron window opened
- manually verified the document selection remains after navigating away from Workchat and then returning
