### PR TITLE
Fix recycling generated task results

### DIFF
--- a/src/views/workchat/sections/rightpanel/WorkspaceTab.vue
+++ b/src/views/workchat/sections/rightpanel/WorkspaceTab.vue
@@ -57,6 +57,18 @@ function taskArtifacts(t) {
   return artifacts.value.filter((a) => ids.includes(a.id))
 }
 
+function clonePlain(value, fallback) {
+  try {
+    return JSON.parse(JSON.stringify(value ?? fallback))
+  } catch {
+    return fallback
+  }
+}
+
+function taskSnapshot(t) {
+  return clonePlain(t, {})
+}
+
 function onTaskProgress(d) {
   const idx = tasks.value.findIndex((t) => t.id === d.taskId)
   if (idx >= 0) {
@@ -184,7 +196,7 @@ async function deleteTaskResults(t) {
   if (!confirmed) return
   const results = []
   for (const artifact of linked) {
-    results.push(await recycleBin.trashArtifact(artifact.id, { title: t.name, task: t }))
+    results.push(await recycleBin.trashArtifact(artifact.id, { title: t.name, task: taskSnapshot(t) }))
   }
   const failed = results.filter((r) => !r.success)
   if (failed.length) {


### PR DESCRIPTION
## Summary
- Fix deletion failure for right-panel creation tool generated results by sending a plain cloned task snapshot through Electron IPC.
- Keep the recycle-bin metadata intact while avoiding Vue reactive Proxy objects that cannot be structured-cloned.

## Validation
- Windows 11, `C:\notebook\Reviva`
- `pnpm build:electron` passed in the Windows project environment
- `git diff --check` and `git diff --cached --check` passed before commit

Closes #6
