### PR TITLE
fix: support PDF files in generation context

### DIFF
--- a/electron/generation/FileContextReader.js
+++ b/electron/generation/FileContextReader.js
@@ -1,6 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { officeRead, setDbService, setWorkDirService } from '../agents/langchainTools.js'
+import { officeRead, pdfRead, setDbService, setWorkDirService } from '../agents/langchainTools.js'
 
 export const TEXT_CONTEXT_EXTS = new Set([
   'md', 'markdown', 'txt', 'json', 'csv', 'tsv', 'yaml', 'yml', 'log',
@@ -8,11 +8,12 @@ export const TEXT_CONTEXT_EXTS = new Set([
   'h', 'sql',
 ])
 export const OFFICE_CONTEXT_EXTS = new Set(['docx', 'xlsx', 'pptx'])
+export const PDF_CONTEXT_EXTS = new Set(['pdf'])
 
 export function isReadableLocalContextItem(item) {
   if (!item?.path || item.isDirectory || item.type === 'folder' || item.type === 'local_folder') return false
   const ext = fileExt(item.path || item.name)
-  return TEXT_CONTEXT_EXTS.has(ext) || OFFICE_CONTEXT_EXTS.has(ext)
+  return TEXT_CONTEXT_EXTS.has(ext) || OFFICE_CONTEXT_EXTS.has(ext) || PDF_CONTEXT_EXTS.has(ext)
 }
 
 function fileExt(filePath) {
@@ -42,6 +43,9 @@ export class FileContextReader {
           if (content) blocks.push({ name: item.name || path.basename(item.path), content })
         } else if (OFFICE_CONTEXT_EXTS.has(ext)) {
           const content = await this._readOfficeFile(item.path, MAX_BYTES)
+          if (content) blocks.push({ name: item.name || path.basename(item.path), content })
+        } else if (PDF_CONTEXT_EXTS.has(ext)) {
+          const content = await this._readPdfFile(item.path, MAX_BYTES)
           if (content) blocks.push({ name: item.name || path.basename(item.path), content })
         }
       } catch (_) {
@@ -84,6 +88,34 @@ export class FileContextReader {
 
   async _invokeOfficeRead(input) {
     const raw = await officeRead.invoke(input)
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw
+    return parsed?.success ? parsed : null
+  }
+
+  async _readPdfFile(filePath, maxBytes) {
+    const parts = []
+    const overview = await this._invokePdfRead({
+      path: filePath,
+      mode: 'overview',
+      maxChars: maxBytes,
+      maxPages: 3,
+    })
+    if (overview?.content) parts.push(overview.content)
+
+    const text = await this._invokePdfRead({
+      path: filePath,
+      mode: 'text',
+      startPage: 1,
+      maxPages: 5,
+      maxChars: maxBytes,
+    })
+    if (text?.content && text.content !== overview?.content) parts.push(text.content)
+
+    return parts.join('\n\n').slice(0, maxBytes * 2)
+  }
+
+  async _invokePdfRead(input) {
+    const raw = await pdfRead.invoke(input)
     const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw
     return parsed?.success ? parsed : null
   }

--- a/src/utils/generationContext.js
+++ b/src/utils/generationContext.js
@@ -1,7 +1,7 @@
 const READABLE_LOCAL_EXTS = new Set([
   'md', 'markdown', 'txt', 'json', 'csv', 'tsv', 'yaml', 'yml', 'log',
   'html', 'htm', 'xml', 'js', 'ts', 'py', 'java', 'go', 'rs', 'c', 'cpp',
-  'h', 'sql', 'docx', 'xlsx', 'pptx',
+  'h', 'sql', 'docx', 'xlsx', 'pptx', 'pdf',
 ])
 
 function fileExt(value) {


### PR DESCRIPTION
## Summary

- Add `pdf` to the readable local context file extension list for generation tools.
- Reuse the existing `pdfRead` pipeline in `FileContextReader` so selected PDF files can provide text context to quiz/flashcard and other generation tools.

Fixes #8

## Verification

- Windows 11 checkout: `C:\notebook\Reviva`
- Real PDF smoke test with Windows Node: generated a temporary PDF and verified `FileContextReader` returned its marker text.
- `pnpm build:electron` passed on Windows.
- Restored generated build artifacts after verification; final commit only changes source files.
- `git diff --check` / cached diff check passed before commit.
