### PR TITLE
稳定学习台聊天消息虚拟滚动

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@langchain/mcp-adapters": "^1.1.3",
     "@langchain/openai": "^1.4.5",
     "@langchain/tavily": "^1.2.0",
+    "@tanstack/vue-virtual": "^3.13.30",
     "better-sqlite3": "^12.9.0",
     "deepagents": "^1.10.2",
     "electron-updater": "^6.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@langchain/tavily':
         specifier: ^1.2.0
         version: 1.2.0(@langchain/core@1.1.46(openai@6.37.0(ws@8.20.1)(zod@4.4.3))(ws@8.20.1))
+      '@tanstack/vue-virtual':
+        specifier: ^3.13.30
+        version: 3.13.30(vue@3.5.34(typescript@5.9.3))
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
@@ -1043,6 +1046,14 @@ packages:
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
+
+  '@tanstack/virtual-core@3.17.2':
+    resolution: {integrity: sha512-w43MvWvmShpb6kIC9MOoLyUkLmRTLPjt61bHWs+X29hACSpX+n8DvgZ3qM7cUfflKlRRcHR9KVJE6TmcqnQvcA==}
+
+  '@tanstack/vue-virtual@3.13.30':
+    resolution: {integrity: sha512-5IpTZf5US81z9CHaRm2imVC44WDU1V/pd8mN1OIvIerRmo6C179UN+vnzlO/dx9Fpt9X7Rjl7fyvolPhPgtfqg==}
+    peerDependencies:
+      vue: ^2.7.0 || ^3.0.0
 
   '@tootallnate/once@2.0.1':
     resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
@@ -5915,6 +5926,13 @@ snapshots:
   '@szmarczak/http-timer@4.0.6':
     dependencies:
       defer-to-connect: 2.0.1
+
+  '@tanstack/virtual-core@3.17.2': {}
+
+  '@tanstack/vue-virtual@3.13.30(vue@3.5.34(typescript@5.9.3))':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.2
+      vue: 3.5.34(typescript@5.9.3)
 
   '@tootallnate/once@2.0.1': {}
 

--- a/src/views/workchat/index.vue
+++ b/src/views/workchat/index.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, nextTick, onMounted, onBeforeUnmount, watch } from 'vue'
 import { useVirtualizer } from '@tanstack/vue-virtual'
+import { storeToRefs } from 'pinia'
 import { useWindowSize } from '@vueuse/core'
 import { useAppStore } from '@/stores/app'
 import { useConversationsStore } from '@/stores/conversations'
@@ -8,6 +9,7 @@ import { useAgentsStore } from '@/stores/agents'
 import { useWikiStore } from '@/stores/wiki'
 import { useSettingsStore } from '@/stores/settings'
 import { useUserStore } from '@/stores/user'
+import { useWorkchatStore } from '@/stores/workchat'
 import { AgentRuntime } from '@/agents/AgentRuntime'
 import { normalizeFilePath } from '@/utils/fileUrl'
 import { readableGenerationContexts } from '@/utils/generationContext'
@@ -41,6 +43,8 @@ const agentsStore = useAgentsStore()
 const wikiStore = useWikiStore()
 const settingsStore = useSettingsStore()
 const userStore = useUserStore()
+const workchatStore = useWorkchatStore()
+const { ctxItems: globalCtxItems } = storeToRefs(workchatStore)
 const isDark = computed(() => appStore.isDark)
 const msg = useMessage()
 
@@ -168,7 +172,6 @@ function findBuiltinAgentByEnglishName(englishName, fallbackIds = []) {
   ))
 }
 
-const globalCtxItems = ref([])
 const currentCtxItems = computed(() => globalCtxItems.value)
 const selectedWikiIds = ref([])
 const availableWikis = computed(() => wikiStore.wikis || [])
@@ -220,7 +223,15 @@ const hasOlderMessages = computed(() => currentConvId.value && !convStore.allMsg
 
 // Smart scroll
 let userScrolledUp = false
+let suppressScrollEventsUntil = 0
+function shouldIgnoreScrollEvent() {
+  return Date.now() < suppressScrollEventsUntil
+}
+function markProgrammaticScroll(behavior = 'auto') {
+  suppressScrollEventsUntil = Date.now() + (behavior === 'smooth' ? 700 : 160)
+}
 function onChatScroll(e) {
+  if (shouldIgnoreScrollEvent()) return
   const el = e.target
   const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120
   userScrolledUp = !nearBottom
@@ -254,6 +265,10 @@ const rowVirtualizer = useVirtualizer(computed(() => ({
   overscan: VIRTUAL_OVERSCAN,
   gap: MESSAGE_GAP,
   scrollPaddingEnd: 160,
+  shouldAdjustScrollPositionOnItemSizeChange: item => {
+    const scrollOffset = chatScrollRef.value?.scrollTop || 0
+    return item.end <= scrollOffset + 1
+  },
 })))
 
 const totalVirtualHeight = computed(() => rowVirtualizer.value.getTotalSize())
@@ -289,8 +304,13 @@ function restoreVirtualAnchor(anchor, el = chatScrollRef.value) {
   return true
 }
 
+let pendingMeasureFrame = 0
 function measureVisibleMessagesSoon() {
-  requestAnimationFrame(() => rowVirtualizer.value.measure())
+  if (pendingMeasureFrame) return
+  pendingMeasureFrame = requestAnimationFrame(() => {
+    pendingMeasureFrame = 0
+    rowVirtualizer.value.measure()
+  })
 }
 
 // Resize
@@ -541,7 +561,7 @@ async function sendMessage(text) {
   userScrolledUp = false
   showScrollBtn.value = false
   await nextTick()
-  scrollToBottom()
+  scrollToBottom('auto')
   await agentRuntime.startChat({
     convId,
     userText: trimmed,
@@ -877,19 +897,22 @@ function handlePreviewFile(file) {
 }
 
 // Scroll
-function scrollToBottom(behavior = 'smooth') {
-  const el = chatScrollRef.value || document.getElementById('chat-scroll')
-  if (el) {
-    rowVirtualizer.value.scrollToIndex(Math.max(0, currentMessages.value.length - 1), { align: 'end', behavior })
-    requestAnimationFrame(() => el.scrollTo({ top: el.scrollHeight, behavior: 'auto' }))
-    userScrolledUp = false
-    showScrollBtn.value = false
-  }
+let pendingScrollFrame = 0
+function scrollToBottom(behavior = 'auto') {
+  if (!chatScrollRef.value || !currentMessages.value.length) return
+  markProgrammaticScroll(behavior)
+  rowVirtualizer.value.scrollToIndex(currentMessages.value.length - 1, { align: 'end', behavior })
+  userScrolledUp = false
+  showScrollBtn.value = false
 }
 
-function scheduleScrollToBottom({ force = false, behavior = 'smooth' } = {}) {
+function scheduleScrollToBottom({ force = false, behavior = 'auto' } = {}) {
   if (!force && userScrolledUp) return
-  requestAnimationFrame(() => scrollToBottom(behavior))
+  if (pendingScrollFrame) return
+  pendingScrollFrame = requestAnimationFrame(() => {
+    pendingScrollFrame = 0
+    scrollToBottom(behavior)
+  })
 }
 
 // Load older messages with ScrollLoader
@@ -897,16 +920,10 @@ async function loadOlderMessages() {
   loadingOlder.value = true
   const el = chatScrollRef.value || document.getElementById('chat-scroll')
   const anchor = findVirtualAnchor(el)
-  const prevScrollHeight = el?.scrollHeight || 0
-  const prevScrollTop = el?.scrollTop || 0
   await convStore.loadMoreMessages(currentConvId.value)
   await nextTick()
   rowVirtualizer.value.measure()
-  if (el) {
-    if (!restoreVirtualAnchor(anchor, el)) {
-      el.scrollTop = el.scrollHeight - prevScrollHeight + prevScrollTop
-    }
-  }
+  restoreVirtualAnchor(anchor, el)
   loadingOlder.value = false
 }
 
@@ -957,7 +974,7 @@ watch(() => [
 
 watch(currentConvId, () => {
   userScrolledUp = false
-  rowVirtualizer.value.scrollToOffset(0, { behavior: 'auto' })
+  showScrollBtn.value = false
   nextTick(() => {
     rowVirtualizer.value.measure()
     scrollToBottom('auto')
@@ -1150,7 +1167,7 @@ function animateTitle(convId, targetTitle, tab) {
           </div>
 
           <!-- Scroll to bottom button -->
-          <button v-if="showScrollBtn" @click="userScrolledUp = false; showScrollBtn = false; scrollToBottom()"
+          <button v-if="showScrollBtn" @click="userScrolledUp = false; showScrollBtn = false; scrollToBottom('smooth')"
             class="absolute bottom-[180px] left-1/2 -translate-x-1/2 h-8 px-3 rounded-full flex items-center gap-1.5 text-[12px] font-medium z-10 transition-all duration-200 shadow-lg"
             :class="isDark
               ? 'bg-d2 border border-d4 text-wt-sub hover:bg-d3 hover:text-wt-main'

--- a/src/views/workchat/index.vue
+++ b/src/views/workchat/index.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, computed, nextTick, onMounted, onBeforeUnmount, watch } from 'vue'
-import { useResizeObserver, useWindowSize } from '@vueuse/core'
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { useWindowSize } from '@vueuse/core'
 import { useAppStore } from '@/stores/app'
 import { useConversationsStore } from '@/stores/conversations'
 import { useAgentsStore } from '@/stores/agents'
@@ -88,20 +89,12 @@ watch(isStreaming, (streaming) => {
 const loadingOlder = ref(false)
 const showScrollBtn = ref(false)
 
-// Virtualized message list. Store still paginates messages; this keeps mounted DOM bounded.
+// Virtualized message list. Store still paginates messages; TanStack keeps mounted DOM bounded.
 const chatScrollRef = ref(null)
-const virtualListRef = ref(null)
-const virtualScrollTop = ref(0)
-const virtualViewportHeight = ref(0)
-const virtualListTop = ref(0)
-const messageHeights = ref({})
 const MESSAGE_GAP = 20
-const VIRTUAL_OVERSCAN = 900
+const VIRTUAL_OVERSCAN = 8
 const EMPTY_STREAM_OBJECT = Object.freeze({})
 const EMPTY_STREAM_ARRAY = Object.freeze([])
-let virtualViewportFrame = 0
-let messageResizeObserver = null
-const observedMessageRows = new Map()
 
 const pendingAuthRequestsByMessageId = computed(() => {
   const map = {}
@@ -229,7 +222,6 @@ const hasOlderMessages = computed(() => currentConvId.value && !convStore.allMsg
 let userScrolledUp = false
 function onChatScroll(e) {
   const el = e.target
-  updateVirtualViewport(el)
   const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 120
   userScrolledUp = !nearBottom
   showScrollBtn.value = !nearBottom && currentMessages.value.length > 0
@@ -254,114 +246,52 @@ function pendingAuthRequestsForMessage(messageId) {
   return pendingAuthRequestsByMessageId.value[messageId] || EMPTY_STREAM_ARRAY
 }
 
-const virtualRows = computed(() => {
-  const rows = []
-  let top = 0
-  const msgs = currentMessages.value
-  for (let i = 0; i < msgs.length; i++) {
-    const message = msgs[i]
-    const height = messageHeights.value[message.id] || estimateMessageHeight(message)
-    rows.push({ index: i, message, top, height })
-    top += height + (i === msgs.length - 1 ? 0 : MESSAGE_GAP)
-  }
-  return rows
-})
+const rowVirtualizer = useVirtualizer(computed(() => ({
+  count: currentMessages.value.length,
+  getScrollElement: () => chatScrollRef.value,
+  estimateSize: index => estimateMessageHeight(currentMessages.value[index]),
+  getItemKey: index => currentMessages.value[index]?.id || index,
+  overscan: VIRTUAL_OVERSCAN,
+  gap: MESSAGE_GAP,
+  scrollPaddingEnd: 160,
+})))
 
-const totalVirtualHeight = computed(() => {
-  const rows = virtualRows.value
-  if (!rows.length) return 0
-  const last = rows[rows.length - 1]
-  return Math.max(1, last.top + last.height)
-})
+const totalVirtualHeight = computed(() => rowVirtualizer.value.getTotalSize())
 
-const visibleVirtualMessages = computed(() => {
-  const rows = virtualRows.value
-  if (!rows.length) return []
-  const localTop = Math.max(0, virtualScrollTop.value - virtualListTop.value)
-  const start = Math.max(0, localTop - VIRTUAL_OVERSCAN)
-  const end = localTop + virtualViewportHeight.value + VIRTUAL_OVERSCAN
-  const visible = []
-  for (const row of rows) {
-    const rowEnd = row.top + row.height
-    if (rowEnd < start) continue
-    if (row.top > end) break
-    visible.push(row)
-  }
-  return visible
-})
+const visibleVirtualMessages = computed(() => rowVirtualizer.value.getVirtualItems().map(item => ({
+  ...item,
+  message: currentMessages.value[item.index],
+})).filter(item => item.message))
 
-function updateVirtualViewport(el = chatScrollRef.value) {
-  if (!el) return
-  virtualScrollTop.value = el.scrollTop
-  virtualViewportHeight.value = el.clientHeight
-  virtualListTop.value = virtualListRef.value?.offsetTop || 0
+function measureVirtualMessageRow(el) {
+  if (el) rowVirtualizer.value.measureElement(el)
 }
 
-function queueVirtualViewportUpdate() {
-  if (virtualViewportFrame) return
-  virtualViewportFrame = requestAnimationFrame(() => {
-    virtualViewportFrame = 0
-    updateVirtualViewport()
+function findVirtualAnchor(el = chatScrollRef.value) {
+  if (!el) return null
+  const items = rowVirtualizer.value.getVirtualItems()
+  if (!items.length) return null
+  const first = items.find(item => item.start + item.size > el.scrollTop + 1) || items[0]
+  const message = currentMessages.value[first.index]
+  if (!message?.id) return null
+  return { id: message.id, offset: el.scrollTop - first.start }
+}
+
+function restoreVirtualAnchor(anchor, el = chatScrollRef.value) {
+  if (!el || !anchor?.id) return false
+  const index = currentMessages.value.findIndex(message => message.id === anchor.id)
+  if (index < 0) return false
+  rowVirtualizer.value.scrollToIndex(index, { align: 'start', behavior: 'auto' })
+  requestAnimationFrame(() => {
+    const item = rowVirtualizer.value.getVirtualItems().find(row => row.index === index)
+    if (item) el.scrollTop = Math.max(0, item.start + anchor.offset)
   })
+  return true
 }
 
-function ensureMessageResizeObserver() {
-  if (messageResizeObserver) return messageResizeObserver
-  messageResizeObserver = new ResizeObserver((entries) => {
-    const nextHeights = { ...messageHeights.value }
-    let changed = false
-    for (const entry of entries) {
-      const id = entry.target.dataset.messageId
-      if (!id) continue
-      const height = Math.ceil(entry.contentRect.height)
-      if (height > 0 && Math.abs((nextHeights[id] || 0) - height) > 1) {
-        nextHeights[id] = height
-        changed = true
-      }
-    }
-    if (!changed) return
-    messageHeights.value = nextHeights
-    queueVirtualViewportUpdate()
-    if (!userScrolledUp) requestAnimationFrame(() => scrollToBottom('auto'))
-  })
-  return messageResizeObserver
+function measureVisibleMessagesSoon() {
+  requestAnimationFrame(() => rowVirtualizer.value.measure())
 }
-
-function observeVirtualMessageRow(el, messageId) {
-  if (!messageId) return
-  const prev = observedMessageRows.get(messageId)
-  if (prev === el) return
-  if (prev) messageResizeObserver?.unobserve(prev)
-  if (!el) {
-    observedMessageRows.delete(messageId)
-    return
-  }
-  const observer = ensureMessageResizeObserver()
-  el.dataset.messageId = messageId
-  observedMessageRows.set(messageId, el)
-  observer.observe(el)
-}
-
-function pruneMessageHeightCache() {
-  const ids = new Set(currentMessages.value.map(m => m.id))
-  const nextHeights = {}
-  for (const [id, height] of Object.entries(messageHeights.value)) {
-    if (ids.has(id)) nextHeights[id] = height
-  }
-  messageHeights.value = nextHeights
-}
-
-function resetVirtualMessages() {
-  observedMessageRows.clear()
-  messageResizeObserver?.disconnect()
-  messageResizeObserver = null
-  messageHeights.value = {}
-  virtualScrollTop.value = 0
-  virtualViewportHeight.value = 0
-  virtualListTop.value = 0
-}
-
-useResizeObserver(chatScrollRef, queueVirtualViewportUpdate)
 
 // Resize
 function onLeftResize(delta) { leftW.value = Math.min(380, Math.max(180, leftW.value + delta)) }
@@ -950,8 +880,8 @@ function handlePreviewFile(file) {
 function scrollToBottom(behavior = 'smooth') {
   const el = chatScrollRef.value || document.getElementById('chat-scroll')
   if (el) {
-    el.scrollTo({ top: el.scrollHeight, behavior })
-    updateVirtualViewport(el)
+    rowVirtualizer.value.scrollToIndex(Math.max(0, currentMessages.value.length - 1), { align: 'end', behavior })
+    requestAnimationFrame(() => el.scrollTo({ top: el.scrollHeight, behavior: 'auto' }))
     userScrolledUp = false
     showScrollBtn.value = false
   }
@@ -966,14 +896,16 @@ function scheduleScrollToBottom({ force = false, behavior = 'smooth' } = {}) {
 async function loadOlderMessages() {
   loadingOlder.value = true
   const el = chatScrollRef.value || document.getElementById('chat-scroll')
+  const anchor = findVirtualAnchor(el)
   const prevScrollHeight = el?.scrollHeight || 0
+  const prevScrollTop = el?.scrollTop || 0
   await convStore.loadMoreMessages(currentConvId.value)
   await nextTick()
-  pruneMessageHeightCache()
-  updateVirtualViewport(el)
+  rowVirtualizer.value.measure()
   if (el) {
-    el.scrollTop = el.scrollHeight - prevScrollHeight + el.scrollTop
-    updateVirtualViewport(el)
+    if (!restoreVirtualAnchor(anchor, el)) {
+      el.scrollTop = el.scrollHeight - prevScrollHeight + prevScrollTop
+    }
   }
   loadingOlder.value = false
 }
@@ -992,7 +924,7 @@ onMounted(() => {
   agentRuntime.registerListeners()
   wikiStore.loadWikis?.().catch(() => {})
   nextTick(() => {
-    updateVirtualViewport()
+    rowVirtualizer.value.measure()
     if (currentMessages.value.length) scrollToBottom('auto')
   })
 })
@@ -1004,8 +936,6 @@ watch(availableWikis, (items) => {
 
 onBeforeUnmount(() => {
   if (_liveTimer) { clearInterval(_liveTimer); _liveTimer = null }
-  if (virtualViewportFrame) cancelAnimationFrame(virtualViewportFrame)
-  messageResizeObserver?.disconnect()
 })
 
 // Smart auto-scroll during streaming
@@ -1021,22 +951,21 @@ watch(() => [
   Object.keys(currentStreamingState.value.subAgents).length,
   currentStreamingState.value.todos.length,
 ], () => {
-  nextTick(queueVirtualViewportUpdate)
+  nextTick(measureVisibleMessagesSoon)
   scheduleScrollToBottom()
 })
 
-watch(currentConvId, (newId, oldId) => {
-  resetVirtualMessages()
+watch(currentConvId, () => {
   userScrolledUp = false
+  rowVirtualizer.value.scrollToOffset(0, { behavior: 'auto' })
   nextTick(() => {
-    updateVirtualViewport()
+    rowVirtualizer.value.measure()
     scrollToBottom('auto')
   })
 })
 
 watch(() => currentMessages.value.map(m => m.id).join('|'), () => {
-  pruneMessageHeightCache()
-  nextTick(queueVirtualViewportUpdate)
+  nextTick(measureVisibleMessagesSoon)
 })
 
 // Typewriter title animation — triggered by titleAnimation signal from AgentRuntime
@@ -1181,14 +1110,14 @@ function animateTitle(convId, targetTitle, tab) {
               :is-dark="isDark"
               @load-more="loadOlderMessages" />
             <div v-if="currentMessages.length"
-              ref="virtualListRef"
               class="relative w-full"
               :style="{ height: totalVirtualHeight + 'px' }">
               <div v-for="item in visibleVirtualMessages"
-                :key="item.message.id"
-                :ref="el => observeVirtualMessageRow(el, item.message.id)"
+                :key="item.key"
+                :data-index="item.index"
+                :ref="measureVirtualMessageRow"
                 class="absolute left-0 right-0 will-change-transform"
-                :style="{ transform: `translateY(${item.top}px)` }">
+                :style="{ transform: `translateY(${item.start}px)` }">
                 <ChatMessage
                   :msg="item.message" :is-dark="isDark"
                   :chat-busy="isStreaming"


### PR DESCRIPTION
## Summary
- replace the custom Workchat message virtual-list height bookkeeping with `@tanstack/vue-virtual`
- keep the chat scroll container performant for long conversations while letting the virtualizer handle dynamic row measurement and scroll anchoring
- preserve the existing Workchat behavior for loading older messages, streaming updates, and scroll-to-bottom controls

Fixes #10

## Validation
- Windows `pnpm install --frozen-lockfile`
- Windows `pnpm build:electron`
- `git diff --check`
- `git diff --cached --check`
- conflict-marker scan on changed files

## Notes
`pnpm build:electron` updates generated artifacts locally (`components.d.ts`, `dist-electron/main.js`, `dist-electron/preload.js`), but those generated files were restored before this commit so the PR only contains the dependency/lockfile and Workchat source changes.
